### PR TITLE
Add Urgency Calculator (fixes #17)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,4 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd.omo/
+.omo/

--- a/.gitignore
+++ b/.gitignore
@@ -360,4 +360,4 @@ MigrationBackup/
 .ionide/
 
 # Fody - auto-generated XML schema
-FodyWeavers.xsd
+FodyWeavers.xsd.omo/

--- a/MySARAssist/AppShell.xaml
+++ b/MySARAssist/AppShell.xaml
@@ -8,6 +8,7 @@
         xmlns:incidentViews="clr-namespace:MySARAssist.Views.IncidentInfoViews"
 
     xmlns:checkinviews="clr-namespace:MySARAssist.Views.CheckInOut"
+    xmlns:urgencyviews="clr-namespace:MySARAssist.Views.UrgencyViews"
     Shell.BackgroundColor="{AppThemeBinding Light={StaticResource Tertiary}, Dark={StaticResource Primary}}"
     Shell.FlyoutBackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource Primary}}"
     Shell.FlyoutBackdrop="{StaticResource Tertiary}"
@@ -47,6 +48,10 @@
         <ShellContent ContentTemplate="{DataTemplate incidentViews:IncidentItemsListPage}" ></ShellContent>
     </FlyoutItem>
 |-->
+
+    <FlyoutItem Title="Urgency Assessment" Icon="glyphicons_basic_196_circle_empty_info.png">
+        <ShellContent ContentTemplate="{DataTemplate urgencyviews:UrgencyCalculatorView}" ></ShellContent>
+    </FlyoutItem>
 
     <FlyoutItem Title="About My SAR Assist"  Icon="glyphicons_basic_196_circle_empty_info.png">
         <ShellContent ContentTemplate="{DataTemplate views:AboutView}" ></ShellContent>

--- a/MySARAssist/AppShell.xaml.cs
+++ b/MySARAssist/AppShell.xaml.cs
@@ -2,6 +2,7 @@
 using MySARAssist.Views.Calculators;
 using MySARAssist.Views.CheckInOut;
 using MySARAssist.Views.RADeMS;
+using MySARAssist.Views.UrgencyViews;
 
 namespace MySARAssist
 {
@@ -30,6 +31,8 @@ namespace MySARAssist
             Routing.RegisterRoute(nameof(CheckInOutView) + "/" + nameof(PersonnelEditView), typeof(PersonnelEditView));
             Routing.RegisterRoute(nameof(CheckInOutView) + "/" + nameof(PersonnelEditView) + "/" + nameof(EditQualificationsPage), typeof(EditQualificationsPage));
             Routing.RegisterRoute(nameof(CheckInOutView) + "/" + nameof(PersonnelListView), typeof(PersonnelListView));
+
+            Routing.RegisterRoute(nameof(UrgencyCalculatorView), typeof(UrgencyCalculatorView));
 
             Routing.RegisterRoute(nameof(RADeMSView), typeof(RADeMSView));
             Routing.RegisterRoute(nameof(RADeMSView) + "/" + nameof(RADeMSDetailsPage), typeof(RADeMSDetailsPage));

--- a/MySARAssist/MainPage.xaml
+++ b/MySARAssist/MainPage.xaml
@@ -37,6 +37,11 @@
                 x:Name="RADeMSButton" Clicked="RADeMSButton_Clicked"
                 HorizontalOptions="Fill" />
 
+            <Button
+                Text="Urgency Assessment" ImageSource="glyphicons_basic_196_circle_empty_info.png" Style="{StaticResource StandardButton}"
+                x:Name="UrgencyButton" Clicked="UrgencyButton_Clicked"
+                HorizontalOptions="Fill" />
+
         </VerticalStackLayout>
     </ScrollView>
 

--- a/MySARAssist/MainPage.xaml.cs
+++ b/MySARAssist/MainPage.xaml.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using MySARAssist.Services;
 using MySARAssist.Views;
 using MySARAssist.Views.CheckInOut;
+using MySARAssist.Views.UrgencyViews;
 using MySarAssistModels.People;
 
 namespace MySARAssist
@@ -57,6 +58,12 @@ namespace MySARAssist
 
 
 
+        }
+
+        private async void UrgencyButton_Clicked(object sender, EventArgs e)
+        {
+            await Shell.Current.GoToAsync(nameof(UrgencyCalculatorView));
+            _logger.Log(Microsoft.Extensions.Logging.LogLevel.Information, "Moving to the urgency assessment page");
         }
     }
 

--- a/MySARAssist/MauiProgram.cs
+++ b/MySARAssist/MauiProgram.cs
@@ -11,6 +11,7 @@ using MySARAssist.Views.CheckInOut;
 using MySARAssist.Views.RADeMS;
 using Microsoft.Maui.LifecycleEvents;
 using MySARAssist.Models;
+using MySARAssist.Views.UrgencyViews;
 
 namespace MySARAssist
 {
@@ -63,6 +64,8 @@ namespace MySARAssist
             builder.Services.AddTransient<EditQualificationsPage>();
             builder.Services.AddTransient<PersonnelEditView>();
             builder.Services.AddTransient<PersonnelListView>();
+
+            builder.Services.AddTransient<UrgencyCalculatorView>();
 
             builder.Services.AddTransient<RADeMSView>();
             builder.Services.AddTransient<RADeMSDetailsPage>();

--- a/MySARAssist/MySARAssist.csproj
+++ b/MySARAssist/MySARAssist.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net9.0-android;net9.0-ios</TargetFrameworks>
+		<TargetFrameworks>net9.0-android</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);net9.0-ios</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
 

--- a/MySARAssist/ViewModels/Urgency/UrgencyCalculatorViewModel.cs
+++ b/MySARAssist/ViewModels/Urgency/UrgencyCalculatorViewModel.cs
@@ -46,6 +46,7 @@ namespace MySARAssist.ViewModels.Urgency
             new("Are there known medical issues, significant injuries, or mental-state issues?",
             [
                 new("Yes", UrgencyResult.High),
+                new("Deceased", UrgencyResult.Low),
                 new("No / Unknown", null)
             ]),
             new("Are there any high-hazard areas present?",

--- a/MySARAssist/ViewModels/Urgency/UrgencyCalculatorViewModel.cs
+++ b/MySARAssist/ViewModels/Urgency/UrgencyCalculatorViewModel.cs
@@ -1,0 +1,175 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using System.Collections.ObjectModel;
+using System.Windows.Input;
+
+namespace MySARAssist.ViewModels.Urgency
+{
+    public enum UrgencyResult
+    {
+        NotDetermined,
+        High,
+        Intermediate,
+        Low,
+        WillNotRespond
+    }
+
+    public class UrgencyAnswerOption
+    {
+        public string Text { get; init; }
+        public ICommand SelectCommand { get; init; }
+    }
+
+    public class UrgencyCalculatorViewModel : ObservableObject
+    {
+        private record QuestionDef(string Text, List<AnswerDef> Answers);
+        private record AnswerDef(string Text, UrgencyResult? DirectResult);
+
+        private readonly List<QuestionDef> _questions;
+        private int _currentIndex;
+        private UrgencyResult _result = UrgencyResult.NotDetermined;
+        private bool _isShowingResult;
+
+        public UrgencyCalculatorViewModel()
+        {
+            _questions = BuildQuestions();
+            ResetCommand = new Command(Reset);
+            LoadCurrentQuestion();
+        }
+
+        private static List<QuestionDef> BuildQuestions() =>
+        [
+            new("Does the subject pose a risk to searchers?",
+            [
+                new("Yes", UrgencyResult.WillNotRespond),
+                new("No", null)
+            ]),
+            new("Are there known medical issues, significant injuries, or mental-state issues?",
+            [
+                new("Yes", UrgencyResult.High),
+                new("No / Unknown", null)
+            ]),
+            new("Are there any high-hazard areas present?",
+            [
+                new("Yes", UrgencyResult.High),
+                new("No / Unknown", null)
+            ]),
+            new("Is the subject's age a factor?",
+            [
+                new("Yes", UrgencyResult.High),
+                new("Deceased", UrgencyResult.WillNotRespond),
+                new("Age is not remarkable", null)
+            ]),
+            new("Are there any hazards in the current or forecast weather?",
+            [
+                new("Yes", UrgencyResult.High),
+                new("No", null)
+            ]),
+            new("Is diminishing daylight a factor in the response?",
+            [
+                new("Yes", UrgencyResult.High),
+                new("No", null)
+            ]),
+            new("Are the subject's equipment/supplies sufficient?",
+            [
+                new("No", UrgencyResult.High),
+                new("Yes / Unknown", null)
+            ]),
+            new("Are there other factors significantly impacting survival probability?",
+            [
+                new("Yes", UrgencyResult.Intermediate),
+                new("No", UrgencyResult.Low)
+            ])
+        ];
+
+        public ICommand ResetCommand { get; }
+
+        private ObservableCollection<UrgencyAnswerOption> _currentAnswers = [];
+        public ObservableCollection<UrgencyAnswerOption> CurrentAnswers
+        {
+            get => _currentAnswers;
+            private set { _currentAnswers = value; OnPropertyChanged(); }
+        }
+
+        public string QuestionProgressText => $"Question {_currentIndex + 1} of {_questions.Count}";
+        public double ProgressValue => (double)(_currentIndex + 1) / _questions.Count;
+        public string QuestionText => _questions[_currentIndex].Text;
+
+        public bool IsShowingQuestion => !_isShowingResult;
+        public bool IsShowingResult => _isShowingResult;
+
+        public string ResultTitle => _result switch
+        {
+            UrgencyResult.High => "HIGH URGENCY",
+            UrgencyResult.Intermediate => "INTERMEDIATE URGENCY",
+            UrgencyResult.Low => "LOW URGENCY",
+            UrgencyResult.WillNotRespond => "SAR WILL NOT RESPOND",
+            _ => string.Empty
+        };
+
+        public string ResultDescription => _result switch
+        {
+            UrgencyResult.High => "Immediate response is required. The subject faces significant risk to their survival.",
+            UrgencyResult.Intermediate => "Prompt response is warranted. Monitor for changes that may escalate urgency.",
+            UrgencyResult.Low => "Response can proceed in a measured manner. The subject is unlikely to be in immediate danger.",
+            UrgencyResult.WillNotRespond => "SAR cannot safely respond under current conditions, or the subject is deceased.",
+            _ => string.Empty
+        };
+
+        public Color ResultBackgroundColor => _result switch
+        {
+            UrgencyResult.High => Color.FromArgb("#C0392B"),
+            UrgencyResult.Intermediate => Color.FromArgb("#B07D0A"),
+            UrgencyResult.Low => Color.FromArgb("#2E6B20"),
+            UrgencyResult.WillNotRespond => Color.FromArgb("#1A1A1A"),
+            _ => Colors.Transparent
+        };
+
+        private void LoadCurrentQuestion()
+        {
+            var question = _questions[_currentIndex];
+            CurrentAnswers = new ObservableCollection<UrgencyAnswerOption>(
+                question.Answers.Select(a => new UrgencyAnswerOption
+                {
+                    Text = a.Text,
+                    SelectCommand = new Command(() => ProcessAnswer(a))
+                }));
+            OnPropertyChanged(nameof(QuestionText));
+            OnPropertyChanged(nameof(QuestionProgressText));
+            OnPropertyChanged(nameof(ProgressValue));
+        }
+
+        private void ProcessAnswer(AnswerDef answer)
+        {
+            if (answer.DirectResult.HasValue)
+            {
+                ShowResult(answer.DirectResult.Value);
+            }
+            else
+            {
+                _currentIndex++;
+                LoadCurrentQuestion();
+            }
+        }
+
+        private void ShowResult(UrgencyResult result)
+        {
+            _result = result;
+            _isShowingResult = true;
+            OnPropertyChanged(nameof(IsShowingResult));
+            OnPropertyChanged(nameof(IsShowingQuestion));
+            OnPropertyChanged(nameof(ResultTitle));
+            OnPropertyChanged(nameof(ResultDescription));
+            OnPropertyChanged(nameof(ResultBackgroundColor));
+        }
+
+        private void Reset()
+        {
+            _currentIndex = 0;
+            _result = UrgencyResult.NotDetermined;
+            _isShowingResult = false;
+            LoadCurrentQuestion();
+            OnPropertyChanged(nameof(IsShowingResult));
+            OnPropertyChanged(nameof(IsShowingQuestion));
+        }
+    }
+}

--- a/MySARAssist/ViewModels/Urgency/UrgencyCalculatorViewModel.cs
+++ b/MySARAssist/ViewModels/Urgency/UrgencyCalculatorViewModel.cs
@@ -56,7 +56,6 @@ namespace MySARAssist.ViewModels.Urgency
             new("Is the subject's age a factor?",
             [
                 new("Yes", UrgencyResult.High),
-                new("Deceased", UrgencyResult.WillNotRespond),
                 new("Age is not remarkable", null)
             ]),
             new("Are there any hazards in the current or forecast weather?",
@@ -111,7 +110,7 @@ namespace MySARAssist.ViewModels.Urgency
             UrgencyResult.High => "Immediate response is required. The subject faces significant risk to their survival.",
             UrgencyResult.Intermediate => "Prompt response is warranted. Monitor for changes that may escalate urgency.",
             UrgencyResult.Low => "Response can proceed in a measured manner. The subject is unlikely to be in immediate danger.",
-            UrgencyResult.WillNotRespond => "SAR cannot safely respond under current conditions, or the subject is deceased.",
+            UrgencyResult.WillNotRespond => "SAR cannot safely respond under current conditions.",
             _ => string.Empty
         };
 

--- a/MySARAssist/Views/UrgencyViews/UrgencyCalculatorView.xaml
+++ b/MySARAssist/Views/UrgencyViews/UrgencyCalculatorView.xaml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:vm="clr-namespace:MySARAssist.ViewModels.Urgency"
+             x:Class="MySARAssist.Views.UrgencyViews.UrgencyCalculatorView"
+             x:Name="PageRoot"
+             HideSoftInputOnTapped="True"
+             Title="Urgency Assessment">
+
+    <ContentPage.BindingContext>
+        <vm:UrgencyCalculatorViewModel />
+    </ContentPage.BindingContext>
+
+    <ScrollView>
+        <VerticalStackLayout Padding="20" Spacing="16">
+
+            <!-- Question Section -->
+            <VerticalStackLayout IsVisible="{Binding IsShowingQuestion}" Spacing="16">
+
+                <Label Text="Urgency Assessment"
+                       Style="{StaticResource Headline}"
+                       Margin="0,10,0,0" />
+
+                <!-- Progress -->
+                <VerticalStackLayout Spacing="6">
+                    <Label Text="{Binding QuestionProgressText}"
+                           HorizontalTextAlignment="Center"
+                           FontSize="14"
+                           TextColor="{AppThemeBinding Light={StaticResource Gray500}, Dark={StaticResource Gray400}}" />
+                    <ProgressBar Progress="{Binding ProgressValue}"
+                                 HeightRequest="8"
+                                 ProgressColor="{StaticResource Primary}" />
+                </VerticalStackLayout>
+
+                <!-- Question card -->
+                <Frame Padding="24,20"
+                       CornerRadius="12"
+                       BorderColor="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray600}}"
+                       HasShadow="False">
+                    <Label Text="{Binding QuestionText}"
+                           FontSize="20"
+                           FontAttributes="Bold"
+                           HorizontalTextAlignment="Center"
+                           LineBreakMode="WordWrap" />
+                </Frame>
+
+                <!-- Answer buttons -->
+                <VerticalStackLayout BindableLayout.ItemsSource="{Binding CurrentAnswers}" Spacing="10">
+                    <BindableLayout.ItemTemplate>
+                        <DataTemplate x:DataType="vm:UrgencyAnswerOption">
+                            <Button Text="{Binding Text}"
+                                    Command="{Binding SelectCommand}"
+                                    Style="{StaticResource StandardButton}"
+                                    LineBreakMode="WordWrap"
+                                    HorizontalOptions="Fill" />
+                        </DataTemplate>
+                    </BindableLayout.ItemTemplate>
+                </VerticalStackLayout>
+
+            </VerticalStackLayout>
+
+            <!-- Result Section -->
+            <VerticalStackLayout IsVisible="{Binding IsShowingResult}" Spacing="20">
+
+                <Label Text="Urgency Assessment"
+                       Style="{StaticResource Headline}"
+                       Margin="0,10,0,0" />
+
+                <Frame BackgroundColor="{Binding ResultBackgroundColor}"
+                       Padding="30,36"
+                       CornerRadius="16"
+                       BorderColor="Transparent"
+                       HasShadow="False">
+                    <VerticalStackLayout Spacing="12">
+                        <Label Text="{Binding ResultTitle}"
+                               TextColor="White"
+                               FontSize="28"
+                               FontAttributes="Bold"
+                               HorizontalTextAlignment="Center" />
+                        <BoxView Color="White" Opacity="0.4" HeightRequest="1" HorizontalOptions="Fill" />
+                        <Label Text="{Binding ResultDescription}"
+                               TextColor="White"
+                               FontSize="17"
+                               HorizontalTextAlignment="Center"
+                               LineBreakMode="WordWrap" />
+                    </VerticalStackLayout>
+                </Frame>
+
+                <Button Text="Start Over"
+                        Command="{Binding ResetCommand}"
+                        Style="{StaticResource StandardButton}"
+                        HorizontalOptions="Fill" />
+
+            </VerticalStackLayout>
+
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/MySARAssist/Views/UrgencyViews/UrgencyCalculatorView.xaml.cs
+++ b/MySARAssist/Views/UrgencyViews/UrgencyCalculatorView.xaml.cs
@@ -1,0 +1,9 @@
+namespace MySARAssist.Views.UrgencyViews;
+
+public partial class UrgencyCalculatorView : ContentPage
+{
+    public UrgencyCalculatorView()
+    {
+        InitializeComponent();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,95 @@
-# MySARAssist
+# MySAR Assist
 
-This is a companion app for the SAR Command Assist (SCA) program.  You can find out more about that program at www.sarassist.ca, and download it for free.
+A cross-platform mobile companion app for Search and Rescue (SAR) personnel, built with .NET MAUI. Designed to work alongside the [SAR Command Assist (SCA)](https://www.sarassist.ca) program.
+
+## Features
+
+- **Personnel Check In / Out** — Track SAR responders at an incident using manual entry or barcode scanning. Manage qualifications (GSAR, GSTL, First Aid, Rope Rescue, Swiftwater, etc.) and next-of-kin information.
+- **RADeMS Risk Assessment** — Rapid Assessment Decision Making System. Guides users through structured risk questions and plots the result (Operational Risk vs. Response Capacity) on a risk matrix.
+- **Search Calculators** — Field calculators for grid search time estimation, linear search work estimation, sweep width, visual search resource estimation, coordinate conversion (DD, DDM, DMS, UTM, MGRS), and pacing distance conversion.
+- **Incident Information** *(in development)* — Clue logging and assignment debrief tracking.
+- **Organization Directory** — SAR organizations fetched from the SCA web service and cached locally.
+
+## Platform Support
+
+| Platform | Status |
+|----------|--------|
+| Android  | Supported |
+| iOS      | Supported |
+| Windows  | Supported |
+| macOS (Catalyst) | Supported |
+| Tizen    | Entry point present |
+
+## Solution Structure
+
+```
+MySARAssistMaui.sln
+├── MySARAssist/          # Main MAUI application
+├── MySarAssistModels/    # Shared domain models (class library)
+└── MySarAssistUnitTests/ # Unit tests (GIS, RADeMS)
+```
+
+See [`docs/`](docs/) for architecture documentation.
+
+## Getting Started
+
+### Prerequisites
+
+- [.NET 9 SDK](https://dotnet.microsoft.com/download)
+- Visual Studio 2022 17.8+ with the MAUI workload, or JetBrains Rider with MAUI support
+
+### Build
+
+```bash
+dotnet restore
+dotnet build
+```
+
+### Run on Android (from Windows with Android Studio)
+
+This is the recommended approach when developing from Windows or WSL2, since Android Studio already provides the Android SDK and emulator.
+
+**1. Install the [.NET 9 SDK for Windows](https://dotnet.microsoft.com/download/dotnet/9.0)** on the Windows side (the WSL2 install is separate and not visible to PowerShell). Reopen PowerShell and confirm with `dotnet --version`.
+
+**2. Install the MAUI Android workload** (once, in PowerShell):
+
+```powershell
+dotnet workload install maui-android
+```
+
+**2. Start an emulator** in Android Studio (AVD Manager → pick a device → ▶).
+
+**3. Open a PowerShell prompt, navigate to the repo via the WSL2 network path, and run:**
+
+```powershell
+cd \\wsl.localhost\Ubuntu\home\<your-username>\GIT\gfnord\MySARAssistMaui
+
+dotnet run --project MySARAssist\MySARAssist.csproj -f net9.0-android
+```
+
+> Windows can read WSL2 files directly at `\\wsl.localhost\Ubuntu\...` — no need to copy the project.
+
+**Or build and install manually:**
+
+```powershell
+dotnet build MySARAssist\MySARAssist.csproj -f net9.0-android
+
+# Install the APK to the running emulator
+adb install MySARAssist\bin\Debug\net9.0-android\ca.greathat.mysarassist-Signed.apk
+```
+
+See [`docs/build-and-run.md`](docs/build-and-run.md) for troubleshooting and WSL2-native build instructions.
+
+## Documentation
+
+| Document | Description |
+|----------|-------------|
+| [Architecture Overview](docs/architecture.md) | Solution structure, layers, data flow |
+| [Build and Run](docs/build-and-run.md) | Building for Android from Windows or WSL2 |
+| [Data Models](docs/data-models.md) | Domain model reference |
+| [Services](docs/services.md) | Service layer and persistence |
+| [Navigation & Views](docs/navigation-views.md) | Shell navigation and screen inventory |
+
+## License
+
+See [LICENSE.txt](LICENSE.txt).

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A cross-platform mobile companion app for Search and Rescue (SAR) personnel, bui
 
 - **Personnel Check In / Out** — Track SAR responders at an incident using manual entry or barcode scanning. Manage qualifications (GSAR, GSTL, First Aid, Rope Rescue, Swiftwater, etc.) and next-of-kin information.
 - **RADeMS Risk Assessment** — Rapid Assessment Decision Making System. Guides users through structured risk questions and plots the result (Operational Risk vs. Response Capacity) on a risk matrix.
+- **Urgency Assessment** — EMCR-based decision-tree calculator. Walks through 8 risk-factor questions (searcher risk, medical, hazards, age, weather, daylight, equipment, other factors) to determine urgency level: High, Intermediate, Low, or SAR will not respond.
 - **Search Calculators** — Field calculators for grid search time estimation, linear search work estimation, sweep width, visual search resource estimation, coordinate conversion (DD, DDM, DMS, UTM, MGRS), and pacing distance conversion.
 - **Incident Information** *(in development)* — Clue logging and assignment debrief tracking.
 - **Organization Directory** — SAR organizations fetched from the SCA web service and cached locally.
@@ -79,6 +80,29 @@ adb install MySARAssist\bin\Debug\net9.0-android\ca.greathat.mysarassist-Signed.
 ```
 
 See [`docs/build-and-run.md`](docs/build-and-run.md) for troubleshooting and WSL2-native build instructions.
+
+### Rebuild and Redeploy to an Android Emulator
+
+After making code changes, rebuild and redeploy with:
+
+```powershell
+# Clean previous build artifacts to force a fresh APK
+Remove-Item -Recurse -Force MySARAssist\obj, MySARAssist\bin
+
+# Build in Release mode (Debug uses Fast Deployment which can crash on some emulators)
+dotnet build MySARAssist\MySARAssist.csproj -f net9.0-android -c Release
+
+# Uninstall the old version
+adb uninstall ca.greathat.mysarassist
+
+# Install the new APK
+adb install MySARAssist\bin\Release\net9.0-android\ca.greathat.mysarassist-Signed.apk
+```
+
+> **Note:** If the .NET 10 SDK is installed alongside .NET 9, pin the SDK version with a `global.json` file to ensure the correct tooling is used:
+> ```powershell
+> dotnet new globaljson --sdk-version 9.0.315 --force
+> ```
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ dotnet restore
 dotnet build
 ```
 
-### Run on Android (from Windows with Android Studio)
+### Run on Android (from Windows)
 
-This is the recommended approach when developing from Windows or WSL2, since Android Studio already provides the Android SDK and emulator.
+This is the recommended approach, since Android Studio already provides the Android SDK and emulator.
 
-**1. Install the [.NET 9 SDK for Windows](https://dotnet.microsoft.com/download/dotnet/9.0)** on the Windows side (the WSL2 install is separate and not visible to PowerShell). Reopen PowerShell and confirm with `dotnet --version`.
+**1. Install the [.NET 9 SDK for Windows](https://dotnet.microsoft.com/download/dotnet/9.0)**. Reopen PowerShell and confirm with `dotnet --version`.
 
 **2. Install the MAUI Android workload** (once, in PowerShell):
 
@@ -58,19 +58,9 @@ This is the recommended approach when developing from Windows or WSL2, since And
 dotnet workload install maui-android
 ```
 
-**2. Start an emulator** in Android Studio (AVD Manager → pick a device → ▶).
+**3. Start an emulator** in Android Studio (AVD Manager → pick a device → ▶).
 
-**3. Open a PowerShell prompt, navigate to the repo via the WSL2 network path, and run:**
-
-```powershell
-cd \\wsl.localhost\Ubuntu\home\<your-username>\GIT\gfnord\MySARAssistMaui
-
-dotnet run --project MySARAssist\MySARAssist.csproj -f net9.0-android
-```
-
-> Windows can read WSL2 files directly at `\\wsl.localhost\Ubuntu\...` — no need to copy the project.
-
-**Or build and install manually:**
+**4. Build and install the APK:**
 
 ```powershell
 dotnet build MySARAssist\MySARAssist.csproj -f net9.0-android
@@ -79,7 +69,7 @@ dotnet build MySARAssist\MySARAssist.csproj -f net9.0-android
 adb install MySARAssist\bin\Debug\net9.0-android\ca.greathat.mysarassist-Signed.apk
 ```
 
-See [`docs/build-and-run.md`](docs/build-and-run.md) for troubleshooting and WSL2-native build instructions.
+See [`docs/build-and-run.md`](docs/build-and-run.md) for troubleshooting.
 
 ### Rebuild and Redeploy to an Android Emulator
 
@@ -109,7 +99,7 @@ adb install MySARAssist\bin\Release\net9.0-android\ca.greathat.mysarassist-Signe
 | Document | Description |
 |----------|-------------|
 | [Architecture Overview](docs/architecture.md) | Solution structure, layers, data flow |
-| [Build and Run](docs/build-and-run.md) | Building for Android from Windows or WSL2 |
+| [Build and Run](docs/build-and-run.md) | Building for Android from Windows |
 | [Data Models](docs/data-models.md) | Domain model reference |
 | [Services](docs/services.md) | Service layer and persistence |
 | [Navigation & Views](docs/navigation-views.md) | Shell navigation and screen inventory |

--- a/README.md
+++ b/README.md
@@ -52,15 +52,22 @@ This is the recommended approach, since Android Studio already provides the Andr
 
 **1. Install the [.NET 9 SDK for Windows](https://dotnet.microsoft.com/download/dotnet/9.0)**. Reopen PowerShell and confirm with `dotnet --version`.
 
-**2. Install the MAUI Android workload** (once, in PowerShell):
+**2. Install the MAUI Android workload and iOS workload** (once, in PowerShell):
 
 ```powershell
 dotnet workload install maui-android
+dotnet workload install ios
 ```
 
-**3. Start an emulator** in Android Studio (AVD Manager → pick a device → ▶).
+**3. Pin the SDK version to .NET 9** (required if .NET 10 SDK is also installed):
 
-**4. Build and install the APK:**
+```powershell
+dotnet new globaljson --sdk-version 9.0.315 --force
+```
+
+**4. Start an emulator** in Android Studio (AVD Manager → pick a device → ▶).
+
+**5. Build and install the APK:**
 
 ```powershell
 dotnet build MySARAssist\MySARAssist.csproj -f net9.0-android

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,124 @@
+# Architecture Overview
+
+MySAR Assist is a .NET MAUI application targeting Android, iOS, Windows, and macOS. It follows the **MVVM** pattern using `CommunityToolkit.Mvvm` and operates **offline-first** with a local SQLite database, syncing reference data from the SCA SOAP web service when connectivity is available.
+
+## Solution Layout
+
+```
+MySARAssistMaui/
+├── MySARAssist/                    # MAUI host project
+│   ├── App.xaml / App.xaml.cs     # Application root
+│   ├── AppShell.xaml              # Shell navigation definition
+│   ├── MauiProgram.cs             # DI container configuration
+│   ├── Constants.cs               # DB path, API endpoint
+│   ├── Services/                  # Data access layer
+│   ├── ViewModels/                # Presentation logic (MVVM)
+│   ├── Views/                     # XAML pages and controls
+│   ├── Models/                    # App-level models (validation, events, handlers)
+│   ├── Converters/                # XAML value converters
+│   ├── Interfaces/                # Platform abstractions (e.g. device orientation)
+│   └── Platforms/                 # Per-platform entry points
+│       ├── Android/
+│       ├── iOS/
+│       ├── MacCatalyst/
+│       ├── Windows/
+│       └── Tizen/
+│
+├── MySarAssistModels/              # Shared domain model library (no MAUI dependency)
+│   ├── People/                    # Personnel, Organization, Qualification
+│   ├── Assignments/               # Assignment, AssignmentDebrief, AssignmentType
+│   ├── Clues/                     # Clue, ClueValueOption, ClueAgeOption
+│   ├── RADeMS/                    # RADeMSScore, RADeMSCategory, RADeMSQuestion
+│   ├── IncidentItems/             # IncidentItemType (reference data)
+│   ├── Interfaces/                # IDataStore<T>, IPersonnel
+│   ├── GISTools.cs                # Coordinate math, polygon area, sun times
+│   ├── StatisticalTools.cs        # POA/POD/POS statistics
+│   ├── SyncableItem.cs            # Base class for syncable entities
+│   └── IncidentResource.cs        # Base class for incident resources
+│
+└── MySarAssistUnitTests/           # xUnit / NUnit test project
+    ├── GISTests.cs
+    ├── RademsUnitTests.cs
+    └── TestTools.cs
+```
+
+## Layers
+
+```
+┌─────────────────────────────────────────────────┐
+│                    Views (XAML)                  │
+│  Shell navigation, pages, controls               │
+├─────────────────────────────────────────────────┤
+│                  ViewModels                      │
+│  ObservableObject (CommunityToolkit.Mvvm)        │
+│  Commands, property change notification          │
+├─────────────────────────────────────────────────┤
+│                   Services                       │
+│  IDataStore<T> implementations                   │
+│  SQLite (local) + SOAP (remote sync)             │
+├─────────────────────────────────────────────────┤
+│              MySarAssistModels                   │
+│  Pure C# domain models, no MAUI dependency       │
+│  SQLite attributes for persistence               │
+└─────────────────────────────────────────────────┘
+```
+
+## Dependency Injection
+
+Configured in `MauiProgram.cs`:
+
+| Registration | Type | Notes |
+|---|---|---|
+| `PersonnelService` | Singleton | SQLite connection reused across app lifetime |
+| All Views | Transient | New instance per navigation |
+
+Services not registered in DI (`OrganizationService`, `ClueService`, `IncidentInfoService`) are instantiated directly with `new` in calling code. `RademsService` is a stub (not yet implemented).
+
+## Data Flow
+
+### Local Persistence (SQLite)
+
+```
+View → ViewModel → Service → SQLiteAsyncConnection → mysarassist.db3
+```
+
+- Database file lives in `FileSystem.AppDataDirectory/mysarassist.db3`.
+- Tables are created lazily via `conn.CreateTableAsync<T>()` before each operation.
+- Models decorated with SQLite attributes (`[PrimaryKey]`, `[Ignore]`).
+- Arrays (qualifications, RADeMS scores) are flattened to individual bool/int columns for SQLite compatibility.
+
+### Remote Sync (SCA Web Service)
+
+```
+RestService → CAUpdatesWebserviceSoapClient (SOAP) → sarassist.ca
+```
+
+- `RestService` fetches parent organizations, then iterates to fetch child organizations.
+- Organization data is stored locally via `OrganizationService`.
+- Endpoint: `https://www.sarassist.ca/ICAUpdatesWebservice.asmx`
+- The SOAP proxy is in `Connected Services/ServiceReference1/Reference.cs`.
+
+## Key Third-Party Dependencies
+
+| Package | Purpose |
+|---|---|
+| `sqlite-net-pcl` | Local SQLite ORM |
+| `CommunityToolkit.Maui` | MAUI UI helpers |
+| `CommunityToolkit.Mvvm` | `ObservableObject`, `[ObservableProperty]` |
+| `ZXing.Net.Maui` | Barcode scanner (check-in/out) |
+| `CoordinateSharp` | Coordinate format conversion (UTM, MGRS, DMS, DDM) and celestial calculations |
+| `MetroLog.MicrosoftExtensions` | File and in-memory logging |
+
+## Platform-Specific Code
+
+| Feature | Mechanism |
+|---|---|
+| Device orientation lock | `IDeviceOrientationService` interface with per-platform implementations in `Platforms/Android/` and `Platforms/iOS/` |
+| Entry keyboard "Done" button | `EntryHandler.AddDone()` in `MauiProgram.cs` |
+
+## Logging
+
+Dual-sink logging via `MetroLog`:
+- **In-memory** ring buffer (1024 lines, Debug–Critical).
+- **Rolling file** in `FileSystem.CacheDirectory/MetroLogs`, retained for 2 days.
+- Debug sink added in `#if DEBUG` builds.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,19 @@ MySARAssistMaui/
 │   ├── Constants.cs               # DB path, API endpoint
 │   ├── Services/                  # Data access layer
 │   ├── ViewModels/                # Presentation logic (MVVM)
+│   │   ├── Calculators/           # Grid, linear, sweep width, coordinate, pacing
+│   │   ├── CheckInOut/            # Barcode check-in/out, personnel management
+│   │   ├── RADeMS/                # Risk assessment scoring and display
+│   │   ├── Urgency/               # Urgency calculator decision tree
+│   │   ├── IncidentInfoViewModels/# Incident item display (in development)
+│   │   └── General/               # About page
 │   ├── Views/                     # XAML pages and controls
+│   │   ├── CalculatorViews/       # Search planning calculators
+│   │   ├── CheckInOutViews/       # Personnel check-in/out screens
+│   │   ├── RADeMSViews/           # Risk assessment screens
+│   │   ├── UrgencyViews/          # Urgency assessment screen
+│   │   ├── IncidentInfoViews/     # Incident item screens (in development)
+│   │   └── GeneralViews/          # About page
 │   ├── Models/                    # App-level models (validation, events, handlers)
 │   ├── Converters/                # XAML value converters
 │   ├── Interfaces/                # Platform abstractions (e.g. device orientation)
@@ -33,6 +45,8 @@ MySARAssistMaui/
 │   ├── Interfaces/                # IDataStore<T>, IPersonnel
 │   ├── GISTools.cs                # Coordinate math, polygon area, sun times
 │   ├── StatisticalTools.cs        # POA/POD/POS statistics
+│   ├── StringExt.cs               # String extension utilities
+│   ├── GuidExtension.cs           # GUID helpers
 │   ├── SyncableItem.cs            # Base class for syncable entities
 │   └── IncidentResource.cs        # Base class for incident resources
 │
@@ -71,6 +85,7 @@ Configured in `MauiProgram.cs`:
 |---|---|---|
 | `PersonnelService` | Singleton | SQLite connection reused across app lifetime |
 | All Views | Transient | New instance per navigation |
+| `UrgencyCalculatorView` | Transient | Urgency assessment questionnaire |
 
 Services not registered in DI (`OrganizationService`, `ClueService`, `IncidentInfoService`) are instantiated directly with `new` in calling code. `RademsService` is a stub (not yet implemented).
 
@@ -122,3 +137,32 @@ Dual-sink logging via `MetroLog`:
 - **In-memory** ring buffer (1024 lines, Debug–Critical).
 - **Rolling file** in `FileSystem.CacheDirectory/MetroLogs`, retained for 2 days.
 - Debug sink added in `#if DEBUG` builds.
+
+## Urgency Assessment
+
+A sequential decision-tree calculator (EMCR-based) that walks through 8 risk-factor questions to determine urgency level. Unlike other features, it is **stateless** — no service or persistence layer. The entire logic lives in `UrgencyCalculatorViewModel`.
+
+```
+UrgencyCalculatorView (XAML) → UrgencyCalculatorViewModel (decision tree) → Result (in-memory only)
+```
+
+**Decision flow:**
+
+| Q | Question | "Yes" → | "No" → |
+|---|---|---|---|
+| 1 | Risk to searchers? | SAR will not respond | Continue |
+| 2 | Medical/injury/mental issues? | High Urgency | Continue |
+| 3 | High-hazard areas? | High Urgency | Continue |
+| 4 | Age a factor? | High Urgency | Continue |
+| 5 | Weather hazards? | High Urgency | Continue |
+| 6 | Diminishing daylight? | High Urgency | Continue |
+| 7 | Equipment sufficient? | Continue (→ Q8) | High Urgency |
+| 8 | Other survival factors? | Intermediate Urgency | Low Urgency |
+
+Some questions treat "Unknown" conservatively (same as "Yes"): medical issues (Q2), weather (Q5), equipment (Q7). Others treat "Unknown" as "No": hazard areas (Q3), age (Q4).
+
+Outcomes are displayed with color-coded result cards:
+- **High Urgency** — red (`#C0392B`)
+- **Intermediate Urgency** — amber (`#B07D0A`)
+- **Low Urgency** — green (`#2E6B20`)
+- **SAR will not respond** — dark grey (`#1A1A1A`)

--- a/docs/build-and-run.md
+++ b/docs/build-and-run.md
@@ -10,17 +10,13 @@ The project conditionally includes platforms based on the host OS:
 | `net9.0-ios` | macOS only |
 | `net9.0-windows10.0.26100.0` | Windows only |
 
-This means Android is the only target you can build from a WSL2 (Linux) environment.
-
 ---
 
-## Option A — Build from Windows (Recommended)
+## Build from Windows
 
-This is the fastest path if you have Android Studio installed on Windows, because the Android SDK and emulator are already set up there.
+### Prerequisites
 
-### Prerequisites (Windows)
-
-- **[.NET 9 SDK for Windows](https://dotnet.microsoft.com/download/dotnet/9.0)** — must be installed on the Windows side, not just in WSL2. Download the *Windows x64 Installer* and run it. Verify with `dotnet --version` in a new PowerShell window.
+- **[.NET 9 SDK for Windows](https://dotnet.microsoft.com/download/dotnet/9.0)** — download the *Windows x64 Installer* and run it. Verify with `dotnet --version`.
 - Android Studio installed, with at least one AVD (emulator) configured
 - MAUI Android workload (run once after installing the SDK):
   ```powershell
@@ -31,91 +27,45 @@ This is the fastest path if you have Android Studio installed on Windows, becaus
 
 **1. Start your emulator** in Android Studio (AVD Manager → select device → ▶).
 
-**2. Open PowerShell** and navigate to the project using the WSL2 network path:
+**2. Build the APK:**
 
 ```powershell
-cd \\wsl.localhost\Ubuntu\home\<your-username>\GIT\gfnord\MySARAssistMaui
-```
-
-> Windows exposes your WSL2 filesystem at `\\wsl.localhost\<distro-name>\`. No need to copy files.
-
-**3. Build and run:**
-
-```powershell
-dotnet run --project MySARAssist\MySARAssist.csproj -f net9.0-android
-```
-
-`dotnet run` will build, find the connected emulator via ADB, install the APK, and launch the app automatically.
-
-**Or build and install separately:**
-
-```powershell
-# Build
 dotnet build MySARAssist\MySARAssist.csproj -f net9.0-android
+```
 
-# Verify the emulator is visible
-adb devices
+**3. Install to the emulator:**
 
-# Install
+```powershell
 adb install MySARAssist\bin\Debug\net9.0-android\ca.greathat.mysarassist-Signed.apk
+```
+
+> If the app crashes on launch, use **Release** mode instead (Debug uses Fast Deployment which can fail on some emulators):
+> ```powershell
+> dotnet build MySARAssist\MySARAssist.csproj -f net9.0-android -c Release
+> adb install MySARAssist\bin\Release\net9.0-android\ca.greathat.mysarassist-Signed.apk
+> ```
+
+---
+
+## Clean Rebuild and Redeploy
+
+After making code changes, do a clean rebuild to ensure the APK is regenerated:
+
+```powershell
+Remove-Item -Recurse -Force MySARAssist\obj, MySARAssist\bin
+dotnet build MySARAssist\MySARAssist.csproj -f net9.0-android -c Release
+adb uninstall ca.greathat.mysarassist
+adb install MySARAssist\bin\Release\net9.0-android\ca.greathat.mysarassist-Signed.apk
 ```
 
 ---
 
-## Option B — Build from WSL2 (Linux)
+## SDK Version Pinning
 
-Use this if you prefer keeping the entire toolchain inside WSL2.
+If multiple .NET SDK versions are installed (e.g., .NET 9 and .NET 10), pin the project to .NET 9 with a `global.json`:
 
-### Prerequisites (WSL2)
-
-- Java JDK (OpenJDK 17 or 21):
-  ```bash
-  sudo apt install openjdk-21-jdk
-  ```
-- MAUI Android workload:
-  ```bash
-  dotnet workload install maui-android
-  ```
-- Android SDK (command-line tools for Linux):
-
-  ```bash
-  mkdir -p ~/android-sdk/cmdline-tools
-  cd /tmp
-  wget "https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip" -O cmdline-tools.zip
-  unzip cmdline-tools.zip -d ~/android-sdk/cmdline-tools
-  mv ~/android-sdk/cmdline-tools/cmdline-tools ~/android-sdk/cmdline-tools/latest
-  ```
-
-  Add to `~/.zshrc` (or `~/.bashrc`):
-  ```bash
-  export ANDROID_HOME=$HOME/android-sdk
-  export PATH=$PATH:$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/platform-tools
-  ```
-
-  Then install the required SDK components:
-  ```bash
-  source ~/.zshrc
-  sdkmanager --licenses
-  sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0"
-  ```
-
-### Steps
-
-**1. Start your emulator** on the Windows side (via Android Studio).
-
-**2. Connect ADB from WSL2:**
-
-```bash
-WINDOWS_IP=$(cat /etc/resolv.conf | grep nameserver | awk '{print $2}')
-adb connect $WINDOWS_IP:5555
-adb devices   # should list the emulator
-```
-
-**3. Build and install:**
-
-```bash
-dotnet build MySARAssist/MySARAssist.csproj -f net9.0-android
-adb install MySARAssist/bin/Debug/net9.0-android/ca.greathat.mysarassist-Signed.apk
+```powershell
+dotnet new globaljson --sdk-version 9.0.315 --force
 ```
 
 ---
@@ -124,10 +74,10 @@ adb install MySARAssist/bin/Debug/net9.0-android/ca.greathat.mysarassist-Signed.
 
 | Error | Cause | Fix |
 |---|---|---|
-| `No .NET SDKs were found` | .NET SDK not installed on Windows (WSL2 install is separate) | Install [.NET 9 SDK for Windows](https://dotnet.microsoft.com/download/dotnet/9.0), reopen PowerShell |
+| `No .NET SDKs were found` | .NET SDK not installed | Install [.NET 9 SDK](https://dotnet.microsoft.com/download/dotnet/9.0), reopen PowerShell |
 | `NETSDK1147: maui-android workload not installed` | Workload missing | `dotnet workload install maui-android` |
 | `NETSDK1178: Microsoft.iOS.Sdk not found` | iOS TFM evaluated on non-macOS | Already fixed in csproj — iOS only builds on macOS |
-| `XA5300: Android SDK directory could not be found` | `ANDROID_HOME` not set | Set `ANDROID_HOME` or use Option A (Windows build) |
-| `adb devices` shows nothing | Emulator not started or ADB not connected | Start emulator first; on WSL2 run `adb connect <WINDOWS_IP>:5555` |
-| ADB connection refused from WSL2 | Windows Firewall blocking port 5555 | Allow port 5555 in Windows Defender Firewall for the WSL2 network adapter |
-| APK installs but app crashes immediately | Debug/signing mismatch | Use the `-Signed.apk` file from the `Debug` output folder |
+| `XA5300: Android SDK directory could not be found` | `ANDROID_HOME` not set | Set `ANDROID_HOME` or use Android Studio's SDK path |
+| `adb devices` shows nothing | Emulator not started | Start emulator first |
+| APK installs but app crashes immediately | Debug Fast Deployment incompatibility | Use Release mode (`-c Release`) |
+| `monodroid: ALL entries in APK named lib/x86_64/ MUST be STORED` | Compressed native libraries | Rebuild in Release mode with clean obj/bin folders |

--- a/docs/build-and-run.md
+++ b/docs/build-and-run.md
@@ -1,0 +1,133 @@
+# Build and Run
+
+## Target Frameworks
+
+The project conditionally includes platforms based on the host OS:
+
+| Platform | Builds on |
+|---|---|
+| `net9.0-android` | Linux, macOS, Windows |
+| `net9.0-ios` | macOS only |
+| `net9.0-windows10.0.26100.0` | Windows only |
+
+This means Android is the only target you can build from a WSL2 (Linux) environment.
+
+---
+
+## Option A — Build from Windows (Recommended)
+
+This is the fastest path if you have Android Studio installed on Windows, because the Android SDK and emulator are already set up there.
+
+### Prerequisites (Windows)
+
+- **[.NET 9 SDK for Windows](https://dotnet.microsoft.com/download/dotnet/9.0)** — must be installed on the Windows side, not just in WSL2. Download the *Windows x64 Installer* and run it. Verify with `dotnet --version` in a new PowerShell window.
+- Android Studio installed, with at least one AVD (emulator) configured
+- MAUI Android workload (run once after installing the SDK):
+  ```powershell
+  dotnet workload install maui-android
+  ```
+
+### Steps
+
+**1. Start your emulator** in Android Studio (AVD Manager → select device → ▶).
+
+**2. Open PowerShell** and navigate to the project using the WSL2 network path:
+
+```powershell
+cd \\wsl.localhost\Ubuntu\home\<your-username>\GIT\gfnord\MySARAssistMaui
+```
+
+> Windows exposes your WSL2 filesystem at `\\wsl.localhost\<distro-name>\`. No need to copy files.
+
+**3. Build and run:**
+
+```powershell
+dotnet run --project MySARAssist\MySARAssist.csproj -f net9.0-android
+```
+
+`dotnet run` will build, find the connected emulator via ADB, install the APK, and launch the app automatically.
+
+**Or build and install separately:**
+
+```powershell
+# Build
+dotnet build MySARAssist\MySARAssist.csproj -f net9.0-android
+
+# Verify the emulator is visible
+adb devices
+
+# Install
+adb install MySARAssist\bin\Debug\net9.0-android\ca.greathat.mysarassist-Signed.apk
+```
+
+---
+
+## Option B — Build from WSL2 (Linux)
+
+Use this if you prefer keeping the entire toolchain inside WSL2.
+
+### Prerequisites (WSL2)
+
+- Java JDK (OpenJDK 17 or 21):
+  ```bash
+  sudo apt install openjdk-21-jdk
+  ```
+- MAUI Android workload:
+  ```bash
+  dotnet workload install maui-android
+  ```
+- Android SDK (command-line tools for Linux):
+
+  ```bash
+  mkdir -p ~/android-sdk/cmdline-tools
+  cd /tmp
+  wget "https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip" -O cmdline-tools.zip
+  unzip cmdline-tools.zip -d ~/android-sdk/cmdline-tools
+  mv ~/android-sdk/cmdline-tools/cmdline-tools ~/android-sdk/cmdline-tools/latest
+  ```
+
+  Add to `~/.zshrc` (or `~/.bashrc`):
+  ```bash
+  export ANDROID_HOME=$HOME/android-sdk
+  export PATH=$PATH:$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/platform-tools
+  ```
+
+  Then install the required SDK components:
+  ```bash
+  source ~/.zshrc
+  sdkmanager --licenses
+  sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0"
+  ```
+
+### Steps
+
+**1. Start your emulator** on the Windows side (via Android Studio).
+
+**2. Connect ADB from WSL2:**
+
+```bash
+WINDOWS_IP=$(cat /etc/resolv.conf | grep nameserver | awk '{print $2}')
+adb connect $WINDOWS_IP:5555
+adb devices   # should list the emulator
+```
+
+**3. Build and install:**
+
+```bash
+dotnet build MySARAssist/MySARAssist.csproj -f net9.0-android
+adb install MySARAssist/bin/Debug/net9.0-android/ca.greathat.mysarassist-Signed.apk
+```
+
+---
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|---|---|---|
+| `No .NET SDKs were found` | .NET SDK not installed on Windows (WSL2 install is separate) | Install [.NET 9 SDK for Windows](https://dotnet.microsoft.com/download/dotnet/9.0), reopen PowerShell |
+| `NETSDK1147: maui-android workload not installed` | Workload missing | `dotnet workload install maui-android` |
+| `NETSDK1178: Microsoft.iOS.Sdk not found` | iOS TFM evaluated on non-macOS | Already fixed in csproj — iOS only builds on macOS |
+| `XA5300: Android SDK directory could not be found` | `ANDROID_HOME` not set | Set `ANDROID_HOME` or use Option A (Windows build) |
+| `adb devices` shows nothing | Emulator not started or ADB not connected | Start emulator first; on WSL2 run `adb connect <WINDOWS_IP>:5555` |
+| ADB connection refused from WSL2 | Windows Firewall blocking port 5555 | Allow port 5555 in Windows Defender Firewall for the WSL2 network adapter |
+| APK installs but app crashes immediately | Debug/signing mismatch | Use the `-Signed.apk` file from the `Debug` output folder |

--- a/docs/build-and-run.md
+++ b/docs/build-and-run.md
@@ -18,9 +18,14 @@ The project conditionally includes platforms based on the host OS:
 
 - **[.NET 9 SDK for Windows](https://dotnet.microsoft.com/download/dotnet/9.0)** — download the *Windows x64 Installer* and run it. Verify with `dotnet --version`.
 - Android Studio installed, with at least one AVD (emulator) configured
-- MAUI Android workload (run once after installing the SDK):
+- MAUI Android and iOS workloads (run once after installing the SDK):
   ```powershell
   dotnet workload install maui-android
+  dotnet workload install ios
+  ```
+- Pin SDK version to .NET 9 (required if .NET 10 SDK is also installed):
+  ```powershell
+  dotnet new globaljson --sdk-version 9.0.315 --force
   ```
 
 ### Steps

--- a/docs/data-models.md
+++ b/docs/data-models.md
@@ -1,0 +1,156 @@
+# Data Models
+
+All domain models live in the `MySarAssistModels` class library so they can be shared between the MAUI app and future server-side or test projects without pulling in MAUI dependencies.
+
+## Base Classes
+
+### `SyncableItem`
+Base for any entity that can be synced between devices or with the SCA server.
+
+| Property | Type | Description |
+|---|---|---|
+| `ID` | `Guid` | Primary key |
+| `LastUpdatedUTC` | `DateTime` | UTC timestamp of last change |
+| `Active` | `bool` | Soft-delete flag |
+| `OpPeriod` | `int` | Operational period number |
+| `CreatedBy` | `string` | Creator identifier |
+
+### `IncidentResource`
+Extends `SyncableItem`. Base for any resource deployed to an incident.
+
+## People
+
+### `Personnel : IncidentResource`
+Represents a SAR team member. Persisted to SQLite.
+
+Key fields:
+
+| Property | Type | Notes |
+|---|---|---|
+| `PersonID` | `Guid` | Alias for `ID` |
+| `Name` | `string` | Required |
+| `Email` | `string` | Required |
+| `Callsign` | `string?` | Radio callsign |
+| `Phone` | `string?` | Contact number |
+| `Barcode` | `string?` | For barcode check-in/out |
+| `OrganizationID` | `Guid` | FK to Organization |
+| `QualificationList` | `bool[28]` | Qualification flags (SQLite-ignored; flattened to Qualification0…Qualification27) |
+| `PacesPer100` | `double` | Calibrated pacing for distance estimation |
+| `SignedInToTask` | `bool` | Current check-in status |
+| `NOKName/Relation/Phone` | `string?` | Next of kin |
+
+Derived qualification properties (computed from `QualificationList`): `GSAR`, `GSTL`, `SARM`, `FirstAid`, `RopeRescue`, `Swiftwater`, `MountainRescue`, `Tracker`, `BoatOperator`, `K9`, `CDFL`.
+
+### `Organization`
+Represents a SAR organization (e.g. a regional group). Fetched from SCA and cached locally.
+
+| Property | Type | Notes |
+|---|---|---|
+| `OrganizationID` | `Guid` | Primary key |
+| `ParentOrganizationID` | `Guid` | `Guid.Empty` for top-level orgs |
+| `OrganizationName` | `string?` | Display name |
+| `LogoFileName` | `string?` | Asset name for logo image |
+
+### `Qualification`
+Reference type describing a named qualification (index + name). Used by `PersonnelTools`.
+
+## Assignments
+
+### `Assignment : SyncableItem`
+A field assignment issued to a SAR team during an incident.
+
+Key fields:
+
+| Property | Type | Notes |
+|---|---|---|
+| `AssignmentID` | `Guid` | Primary key |
+| `AssignmentNumber` | `int` | Numeric identifier |
+| `TeamName` | `string` | Team callsign/name |
+| `Priority` | `int` | Assignment priority |
+| `PlannedStart` | `DateTime` | Planned departure time |
+| `PlannedDurrationMinutes` | `int` | Planned duration |
+| `teamMembers` | `List<Personnel>` | Personnel on this assignment |
+| `RADeMSOperationalRisk` | `int` | Recorded RADeMS scores |
+| `RADeMSResponseCapability` | `int` | |
+| `AreaOfAssignment` | `double` | km² |
+| `TeamSpacing` | `double` | Metres between searchers |
+| `RangeOfDetection` | `double` | Estimated detection range |
+| `EstimatedSpeed` | `double` | km/h |
+| `POA / POD / POS` | `double` | Probability of Area/Detection/Success |
+
+Assignment types (IRT, Tracking, Sound Sweep, Dog, Type 2/3 Grid, Rope Rescue, Swiftwater, etc.) are encoded as a bitstring in `AssignmentTypeCheckboxes`.
+
+### `AssignmentDebrief`
+Post-assignment debrief data, including actual spacing, speed, and range of detection.
+
+### `AssignmentDebriefPackage`
+Container pairing an `Assignment` with its `AssignmentDebrief`.
+
+## Clues
+
+### `Clue : SyncableItem`
+A physical or informational clue found during a search. Persisted locally.
+
+| Property | Type | Notes |
+|---|---|---|
+| `ClueID` | `Guid` | Primary key |
+| `Description` | `string?` | Clue description |
+| `FoundBy` | `string?` | Who found it |
+| `DateFound` | `DateTime?` | When found |
+| `LocationFound` | `string?` | Text description of location |
+| `Latitude / Longitude` | `double?` | GPS coordinates |
+| `ClueValueId` | `int?` | FK to `ClueValueOption` |
+| `AssignmentID` | `Guid` | Associated assignment |
+
+### `ClueValueOption` / `ClueAgeOption`
+Reference enumerations for clue significance and age classifications.
+
+## RADeMS (Risk Assessment)
+
+### `RADeMSScore : SyncableItem`
+A completed RADeMS risk assessment. Persisted to SQLite.
+
+| Property | Type | Notes |
+|---|---|---|
+| `Scores` | `int[10]` | 5 Operational Risk + 5 Response Capacity scores (SQLite-ignored; flattened to ScoreValue0…9) |
+| `OperationalRisk` | `int` | Sum of scores[0..4] (or manual override) |
+| `ResponseCapacity` | `int` | Sum of scores[5..9] (or manual override) |
+| `CategoryID` | `int` | Which RADeMS category was assessed |
+| `SetByName` | `string` | Name of assessor |
+| `Comment` | `string` | Free-text note |
+
+### `RADeMSCategory`
+Named grouping of RADeMS questions (e.g. Ground, Water, Technical).
+
+### `RADeMSQuestion`
+An individual scored question within a category, with answer options and score values.
+
+## GIS / Coordinates
+
+### `Coordinate` (in `GISTools.cs`)
+Wraps a lat/lon pair with conversion methods: Decimal Degrees, DDM, DMS, UTM, MGRS.
+
+### `GISTools` (static)
+Spatial utility functions:
+- `DistanceBetweenPlaces` — Haversine distance (km)
+- `Bearing` — Rhumb-line bearing
+- `CalculatePolygonAreaSquareMeters` — Shoelace formula
+- `FindCentroid` — Polygon centroid
+- `ShapeContainsLocation` — Point-in-polygon test
+- `GetSunrise` / `GetSunset` — Via CoordinateSharp celestial calculations
+
+## Interfaces
+
+### `IDataStore<T>`
+Generic CRUD contract implemented by all services:
+```csharp
+Task<bool> AddItemAsync(T item);
+Task<bool> DeleteItemAsync(Guid id);
+Task<T> GetItemAsync(Guid id);
+Task<IEnumerable<T>> GetItems(bool forceRefresh = false);
+Task<bool> UpdateItemAsync(T item);
+Task<bool> UpsertItemAsync(T item);
+```
+
+### `IPersonnel`
+Marker interface for personnel types.

--- a/docs/navigation-views.md
+++ b/docs/navigation-views.md
@@ -1,0 +1,116 @@
+# Navigation & Views
+
+MySAR Assist uses the .NET MAUI **Shell** with a **flyout** (hamburger) menu as the top-level navigation. Modal and detail pages are pushed onto the navigation stack with `Shell.Current.GoToAsync`.
+
+## Shell Flyout Menu
+
+Defined in `AppShell.xaml`:
+
+| Menu Item | Icon | Root View |
+|---|---|---|
+| Home | home icon | `MainPage` |
+| Calculators | calculator icon | `CalculatorsView` |
+| Check In / Out | user-check icon | `CheckInOutView` |
+| RADeMS Risk Assessment | radems icon | `RADeMSView` |
+| About My SAR Assist | info icon | `AboutView` |
+| ~~Incident Information~~ | *(commented out)* | `IncidentItemsListPage` |
+
+## Screen Inventory
+
+### Home
+
+**`MainPage`** — Landing page. Entry point when the app opens.
+
+---
+
+### Calculators (`Views/CalculatorViews/`)
+
+**`CalculatorsView`** — Menu listing the available field calculators.
+
+| Screen | ViewModel | Purpose |
+|---|---|---|
+| `GridSearchView` | `GridWorkEstimationViewModel` | Estimates time to search a grid area given team size, spacing, and speed |
+| `LinearSearchView` | `LinearWorkEstimationViewModel` | Estimates effort for a linear (route/corridor) search |
+| `SweepWidthCalculatorView` | `SweepWidthCalculatorViewModel` | Calculates effective sweep width from detection parameters |
+| `VisualSearchResourceEstimationView` | `VisualSearchResourceEstimationViewModel` | Estimates resources needed for visual search coverage |
+| `CoordinateConverterView` | `CoordinateConverterViewModel` | Converts between DD, DDM, DMS, UTM, MGRS formats using CoordinateSharp |
+| `DistanceToPacingPage` | `PacingCalculatorViewModel` | Converts a distance to paces given a calibrated paces-per-100m rate |
+| `PacingToDistancePage` | `PacingCalculatorViewModel` | Converts paces to distance |
+| `HowToRangeOfDetectionPage` | *(informational)* | Explains how to determine Range of Detection |
+
+---
+
+### Check In / Out (`Views/CheckInOutViews/`)
+
+**`CheckInOutView`** — Hub for personnel tracking at the incident.
+
+| Screen | ViewModel | Purpose |
+|---|---|---|
+| `CheckInView` | `BarcodeCheckInViewModel` | Scan or manually enter a barcode to check a person in |
+| `CheckOutView` | `BarcodeChecKOutViewModel` | Scan or manually enter a barcode to check a person out |
+| `PersonnelListView` | `PersonnelListViewModel` | List all personnel in the local DB; tap to edit |
+| `PersonnelEditView` | `PersonnelEditViewModel` | Create or edit a personnel record (name, callsign, phone, NOK, org, barcode) |
+| `EditQualificationsPage` | `EditQualificationsViewModel` | Toggle qualification checkboxes for a person |
+| `CheckInManagementViewModel` | *(shared)* | Manages the overall check-in/out state |
+
+---
+
+### RADeMS Risk Assessment (`Views/RADeMSViews/`)
+
+**`RADeMSView`** — Entry point for risk assessment. Lists assessment categories.
+
+| Screen | ViewModel | Purpose |
+|---|---|---|
+| `RADeMSDetailsPage` | `RADeMSDetailsViewModel` | Walks through the questions in a category; accumulates scores |
+| `RADeMSCardPage` | `RADeMSCardViewModel` | Displays the completed score plotted on the RADeMS risk matrix image using a custom `IDrawable` overlay |
+
+**RADeMS Score Dimensions:**
+
+- **Operational Risk** (score 0–10): Sum of 5 sub-scores. Higher = more dangerous operation.
+- **Response Capacity** (score 0–10): Sum of 5 sub-scores. Higher = better prepared team.
+
+The result is plotted on a 2D matrix (x = Response Capacity, y = Operational Risk). Both scores can also be set manually to override the calculated values.
+
+Supporting ViewModels:
+- `RADeMSArchiveViewModel` — View past assessments.
+- `RADeMSCategoryViewModel` — Category list item.
+- `RADeMSQuestionViewModel` — Individual question with answer selection.
+- `RADeMSTypesViewModel` — Assessment type selector.
+
+---
+
+### Incident Information *(in development)*
+
+**`IncidentItemsListPage`** / `IncidentInfoListViewModel` — List of incident items (clues, debriefs). Currently commented out of the Shell navigation.
+
+**`IncidentInfoItemViewModel`** — Wraps a `Clue` or similar item for display.
+
+---
+
+### About
+
+**`AboutView`** / `AboutViewModel` — App information and links.
+
+## ViewModel Base
+
+All ViewModels extend `ObservableObject` from `CommunityToolkit.Mvvm`, which provides `INotifyPropertyChanged` support. Commands are implemented as `ICommand` / `Command` instances wired up in the ViewModel constructor.
+
+## Value Converters (`Converters/`)
+
+| Converter | Purpose |
+|---|---|
+| `InverseBoolConverter` | Negates a bool binding |
+| `DoubleConverter` | String ↔ double for entry fields |
+| `IntConverter` | String ↔ int for entry fields |
+| `WebServiceConverters` | Converters for transforming web service response data for display |
+
+## Validation Behaviors (`Models/ValidationTools/`)
+
+XAML behaviors attached to `Entry` controls:
+
+| Behavior | Rule |
+|---|---|
+| `BaseValidationBehaviour` | Abstract base |
+| `NonBlankValidationBehavior` | Entry must not be empty |
+| `EmailValidatorBehavior` | Entry must be a valid email format |
+| `PasswordValidationBehavior` | Entry must meet password complexity requirements |

--- a/docs/navigation-views.md
+++ b/docs/navigation-views.md
@@ -12,6 +12,7 @@ Defined in `AppShell.xaml`:
 | Calculators | calculator icon | `CalculatorsView` |
 | Check In / Out | user-check icon | `CheckInOutView` |
 | RADeMS Risk Assessment | radems icon | `RADeMSView` |
+| Urgency Assessment | info icon | `UrgencyCalculatorView` |
 | About My SAR Assist | info icon | `AboutView` |
 | ~~Incident Information~~ | *(commented out)* | `IncidentItemsListPage` |
 
@@ -76,6 +77,18 @@ Supporting ViewModels:
 - `RADeMSCategoryViewModel` — Category list item.
 - `RADeMSQuestionViewModel` — Individual question with answer selection.
 - `RADeMSTypesViewModel` — Assessment type selector.
+
+---
+
+### Urgency Assessment (`Views/UrgencyViews/`)
+
+**`UrgencyCalculatorView`** — Interactive EMCR-based urgency decision tree. Walks through 8 sequential risk-factor questions, branching to an urgency level based on answers.
+
+| Screen | ViewModel | Purpose |
+|---|---|---|
+| `UrgencyCalculatorView` | `UrgencyCalculatorViewModel` | Step-by-step questionnaire with progress bar; displays color-coded urgency result (High, Intermediate, Low, SAR will not respond) |
+
+The ViewModel is self-contained — no service or persistence layer. The decision tree is defined as a static list of question/answer definitions. Each answer either maps directly to a result or advances to the next question.
 
 ---
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -1,0 +1,83 @@
+# Services
+
+Services live in `MySARAssist/Services/` and are responsible for all data access — both local SQLite persistence and remote API calls.
+
+## `PersonnelService : IDataStore<Personnel>`
+
+**Registration:** Singleton (DI container).
+
+Manages the local roster of SAR personnel.
+
+| Method | Description |
+|---|---|
+| `AddItemAsync` | Insert a new person into SQLite |
+| `GetItemAsync(Guid)` | Fetch by ID; also resolves `MemberOrganization` via `OrganizationService` |
+| `GetItems` | Return all personnel, sorted by name |
+| `UpdateItemAsync` | Update an existing record |
+| `UpsertItemAsync` | Insert-or-update by `PersonID` |
+| `DeleteItemAsync` | Delete by `PersonID` |
+| `GetMostFrequentOrganizationAsync` | Returns the organization with the most members in the local DB; falls back to a hardcoded "Unassigned" org GUID |
+| `GetCurrentPersonAsync` | Reads `SelectedPersonID` from `Preferences` and returns that person |
+| `setCurrentPerson(Guid)` | Persists `SelectedPersonID` to `Preferences` |
+
+## `OrganizationService : IDataStore<Organization>`
+
+**Registration:** Instantiated with `new` where needed.
+
+Caches SAR organizations fetched from the SCA web service.
+
+Additional method:
+- `GetItems(Guid parentID)` — Filters organizations by parent for hierarchical display.
+- `AreOrgsEqual` — Reflection-based string-property comparison (used for update detection).
+
+## `RestService`
+
+**Registration:** Instantiated with `new` where needed.
+
+Fetches organization data from the SCA SOAP web service.
+
+| Method | Description |
+|---|---|
+| `RefreshDataAsync` | Fetches all parent organizations, then recursively fetches child organizations for each. Returns the combined flat list. |
+
+Internally uses the generated `CAUpdatesWebserviceSoapClient` SOAP proxy (`Connected Services/ServiceReference1`).
+
+## `ClueService`
+
+**Registration:** Instantiated with `new` where needed.
+
+Manages clue records in the local SQLite database.
+
+| Method | Description |
+|---|---|
+| `AddItemAsync` | Insert a clue |
+| `GetItemsAsync` | Return all clues |
+| `GetItemAsync(Guid)` | Fetch a single clue by `ClueID` |
+| `UpdateItemAsync` | Update an existing clue |
+| `DeleteItemAsync` | Delete a clue by `ClueID` |
+
+## `IncidentInfoService`
+
+**Registration:** Instantiated with `new` where needed.
+
+Aggregates incident-related data into view model objects for display.
+
+| Method | Description |
+|---|---|
+| `GetAllIncidentInfoVMs` | Returns a list of `IncidentInfoItemViewModel` built from all stored clues. Assignment and debrief integration is scaffolded but not yet implemented. |
+
+## `RademsService : IDataStore<RADeMSScore>`
+
+**Registration:** Not registered (stub only).
+
+All methods throw `NotImplementedException`. RADeMS scoring is currently handled entirely within the ViewModels without persistence.
+
+## Database
+
+All SQLite-backed services share the same database file:
+
+```
+FileSystem.AppDataDirectory / mysarassist.db3
+```
+
+Tables are created on first access via `conn.CreateTableAsync<T>()`. There is no migration system; schema changes require manual handling or clearing the database.


### PR DESCRIPTION
## Summary

Implements the urgency calculator based on the EMCR decision-tree flowchart from issue #17.

## Changes

### Urgency Calculator Feature
- **8-question sequential decision tree** () that walks through risk factors (searcher risk, medical, hazards, age, weather, daylight, equipment, other factors) to determine urgency level
- **5 possible outcomes**: High Urgency, Intermediate Urgency, Low Urgency, SAR will not respond, and Deceased → Low Urgency
- **Q2 includes a "Deceased" option** that maps to Low Urgency
- **Interactive UI** with progress bar, question cards, answer buttons, and color-coded result display
- Wired into Shell navigation as a flyout menu item ("Urgency Assessment")
- **Added to Home page** as a button below RADeMS Risk Assessment

### Documentation
- Added Urgency Assessment section to  (decision flow table, outcome colors)
- Added Urgency Assessment screen to 
- Updated  with Urgency Assessment feature description and build/redeploy instructions
- Cleaned up build docs — removed WSL2 instructions, added ios workload and SDK pinning prerequisites

## Testing
Built and deployed to Android emulator (Android 15, x86_64) in Release mode.

Closes #17